### PR TITLE
ci: pin actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install the project
         run: uv sync --locked --dev # --all-extras
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload package distributions to GitHub
         if: ${{ matrix.python-version == '3.13' }} # upload only on latest supported Python
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: package
           path: dist/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,13 +24,13 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package
           path: dist/
 
         # https://docs.pypi.org/trusted-publishers/using-a-publisher/
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ inputs.publish-to }}


### PR DESCRIPTION
Fixes CI, which is currently red on every branch.

## Problem

The repo now enforces SHA pinning for GitHub Actions (`sha_pinning_required: true`). Every workflow run fails during action resolution, before a single step executes:

```
The actions actions/checkout@v7, astral-sh/setup-uv@v7, and actions/upload-artifact@v7
are not allowed in cj81499/json_types because all actions must be pinned to a
full-length commit SHA.
```

This landed between 2026-07-27 (last green run) and 2026-08-03 (first red). It is not Dependabot-specific — pushes to `main` fail the same way — but it is most visible on the four open Dependabot PRs (#71, #73, #74, #75), none of which have been able to run their checks. The `Process completed with exit code 1` error alongside it is just the `collector` job reporting the upstream failure, not a separate problem.

## Change

| action | was | now |
| --- | --- | --- |
| `actions/checkout` | `@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `astral-sh/setup-uv` | `@v7` | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` # v7.6.0 |
| `actions/upload-artifact` | `@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1 |
| `actions/download-artifact` | `@v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` # v8.0.1 |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` # v1.14.2 |

`release.yaml` is fixed alongside `build-and-test.yaml`. It is `workflow_dispatch`-only so it has not run since the policy landed and is not visibly red, but it would fail identically on the next release.

Each action is pinned to the newest patch of the major version already in use, so this is a pin-format change only. Two things worth a reviewer's attention:

- **`pypa/gh-action-pypi-publish` was a branch ref**, so pinning it is a real behavior change — it stops auto-tracking `release/v1` and freezes at v1.14.2. That is the intent of the policy, and Dependabot will keep it moving.
- **`astral-sh/setup-uv` is pinned to the newest v7 (v7.6.0), not the newest overall (v10.0.0).** Major bumps are deliberately left to separate PRs so they can be reviewed on their merits.

Local reusable-workflow refs (`uses: ./.github/workflows/build-and-test.yaml`) are exempt from the policy and unchanged.

Dependabot's `github-actions` ecosystem preserves SHA pin style and updates the trailing `# vX.Y.Z` comments, so `.github/dependabot.yml` needs no changes.

## Follow-ups

Once this merges, the open Dependabot PRs need a `@dependabot rebase` to pick up the fixed workflows. Worth flagging that #73 (`flit-core` 3.x -> 4.x) is a major bump of the build backend and is the most likely to fail for real once CI can actually run.

## Testing

Every pinned SHA was verified to resolve upstream and to be the commit its tag points to. Beyond that, this is a workflow-only change — CI on this PR is the real test, and it is the thing being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)