### PR TITLE
ci: set up zizmor static analysis for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -18,4 +20,6 @@ updates:
       artifacts:
         patterns:
           - "actions/*-artifact"
+    cooldown:
+      default-days: 7
   

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,14 +5,19 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build-and-test:
+    permissions:
+      contents: read # to check out the repository
     uses: ./.github/workflows/build-and-test.yaml
 
   collector:
     needs: [build-and-test]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check for failures
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,12 @@ on:
           - https://test.pypi.org/legacy/ # for testing
           - https://upload.pypi.org/legacy/ # for release
 
+permissions: {}
+
 jobs:
   build-and-test:
+    permissions:
+      contents: read # to check out the repository
     uses: ./.github/workflows/build-and-test.yaml
 
   publish:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,21 @@
+name: Security analysis (zizmor)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository
+      security-events: write # to upload SARIF results to code scanning
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Closes #77.

Adds [zizmor](https://github.com/zizmorcore/zizmor) and fixes everything it found. Four commits, one concern each, so any can be dropped independently.

## What zizmor actually found

I ran `zizmor` against the repo (v1.29.0, `regular` persona, online audits enabled) rather than guessing. 8 findings:

| audit | count | commit |
| --- | --- | --- |
| `excessive-permissions` | 5 | `8147932` |
| `artipacked` | 1 | `e789338` |
| `dependabot-cooldown` | 2 | `34e49cc` |

**`template-injection` did not fire**, contrary to what I speculated in #77. `${{ inputs.publish-to }}` in `release.yaml` is a `workflow_dispatch` choice input constrained to two fixed options, so it is not attacker-controlled. Correcting that here since the issue text says otherwise.

After these commits, `zizmor .` reports `No findings to report` both offline and with online audits enabled.

### `excessive-permissions` (5)

Neither `ci.yaml` nor `release.yaml` declared a `permissions:` block, so every job ran with the repo default rather than what it needs. Both now default to `permissions: {}` and grant back per job: `contents: read` for jobs that check out, nothing for `collector`. The `publish` job is untouched — its `id-token: write` was already explicit and minimal, and zizmor did not flag it.

### `artipacked` (1)

`actions/checkout` persists `GITHUB_TOKEN` into the runner's git config by default, where later steps can read it and it can end up in uploaded artifacts — and this workflow does upload artifacts. Nothing uses git after checkout, so `persist-credentials: false`.

### `dependabot-cooldown` (2)

**This is the one judgment call, and the one I would most expect you to push back on.** It changes update cadence rather than fixing a defect: a 7-day cooldown means Dependabot PRs arrive up to a week later. The argument for it is that a compromised release is most dangerous immediately after publication, and this repo's Dependabot traffic is entirely dev-tooling patches, so the delay costs little. Isolated in `34e49cc` — drop that commit and the rest still stands.

## Resolving the open question from #77

I proposed adding zizmor to the `collector` job's `needs` so it would gate merges. **That does not work.** With `advanced-security: true` (the default), the action deliberately *does not fail the job* when it reports findings — in SARIF mode it defers blocking to code scanning and rulesets. Wiring it into `collector` would gate nothing.

So it is a standalone workflow. Also kept separate because it needs `security-events: write` to upload SARIF, and folding that scope into `ci.yaml` contradicts the least-privilege fix in the same PR.

**Consequence worth knowing:** as-is, zizmor findings are visible but not merge-blocking. Making them block requires enabling the code scanning check in the branch ruleset — a repository setting I cannot change from a PR. Happy to file a follow-up issue if you want that.

## Notes

- Both actions in the new workflow are SHA-pinned per the policy from #76.
- `actions: read` is omitted from the job permissions; it is only needed for private repositories, and this one is public.
- Dependabot's existing `github-actions` ecosystem config picks up the new workflow automatically.

## Testing

`zizmor` was run locally before and after each fix, offline and online, confirming findings went 8 → 0. Repo checks (ruff format/check, tombi format/lint, mypy, pytest) pass locally, though nothing here touches Python.

The workflow itself has not run yet — CI on this PR is its first execution, which is why this is a draft. The thing I would watch for is the SARIF upload permissions being wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)